### PR TITLE
Fix three real lint-surfaced bugs in admin components

### DIFF
--- a/frontend-vite/src/components/admin/gameReport/RulesEditor.vue
+++ b/frontend-vite/src/components/admin/gameReport/RulesEditor.vue
@@ -43,7 +43,7 @@ store.publicStore.waitForAllVariablesPresent().then(() => {
         </Tab>
       </TabList>
       <TabPanels>
-        <TabPanel v-for="code in store.publicStore.codes" key="id" :value="code.id" class="bg-surface-700">
+        <TabPanel v-for="code in store.publicStore.codes" :key="code.id" :value="code.id" class="bg-surface-700">
           <div class="flex flex-col">
             <div class="flex flex-row justify-center">
               <Button label="Add Rule" icon="pi pi-plus" class="p-button-success m-2" @click="addRule()"/>

--- a/frontend-vite/src/components/admin/gameReport/SingleGameTypeEditor.vue
+++ b/frontend-vite/src/components/admin/gameReport/SingleGameTypeEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 
 import type {GameType} from "@/types";
+import {ref, watch} from "vue";
 
 const props = defineProps<{
   gameType: GameType
@@ -10,29 +11,36 @@ const emit = defineEmits<{
   (e: 'on_cancel', gameType: GameType): void
 }>()
 
-function onSaveEdit(gameType: GameType) {
-  emit('on_save', gameType)
+// Edit on a local copy so typing does not mutate the shared store object
+// directly (which previously also meant Cancel could not revert changes).
+const localGameType = ref<GameType>({...props.gameType})
+watch(() => props.gameType, (gameType) => {
+  localGameType.value = {...gameType}
+})
+
+function onSaveEdit() {
+  emit('on_save', localGameType.value)
 }
-function onCancelEdit(gameType: GameType) {
-  emit('on_cancel', gameType)
+function onCancelEdit() {
+  emit('on_cancel', localGameType.value)
 }
 </script>
 <template>
   <div class="flex flex-row">
     <div class="p-1 flex-grow">
       <InputText
-          v-model="gameType.name"
+          v-model="localGameType.name"
           class="w-full"
-          @keyup.enter="onSaveEdit(gameType)"
+          @keyup.enter="onSaveEdit()"
       />
     </div>
     <div class="p-2">
 
-      <vue-feather class="hover:cursor-pointer" type="x" @click="onCancelEdit(gameType)"/>
+      <vue-feather class="hover:cursor-pointer" type="x" @click="onCancelEdit()"/>
     </div>
   </div>
   <div class="p-1">
-    <Button @click="onSaveEdit(gameType)" class="p-button-sm p-button-success m-1">Save</Button>
+    <Button @click="onSaveEdit()" class="p-button-sm p-button-success m-1">Save</Button>
   </div>
 </template>
 

--- a/frontend-vite/src/components/admin/teams/TeamList.vue
+++ b/frontend-vite/src/components/admin/teams/TeamList.vue
@@ -81,7 +81,7 @@ function onAmalgamationEdited(team: Team) {
 }
 
 const orderedTeamsList = computed(() => {
-  return props.teams.sort((a, b) => a.name > b.name ? 1 : -1)
+  return [...props.teams].sort((a, b) => a.name > b.name ? 1 : -1)
 })
 </script>
 


### PR DESCRIPTION
Three genuine bugs surfaced by a project-wide ESLint pass (separate from feature work).

## Bugs fixed
- **`RulesEditor.vue`** — the `TabPanel` `v-for` used a **static string** `key="id"`, so every panel shared the identical key `"id"` (Vue can reuse/confuse panel DOM). Now `:key="code.id"`. *(`vue/valid-v-for`)*
- **`TeamList.vue`** — `orderedTeamsList` computed called `props.teams.sort(...)`, sorting the prop array **in place** as a computed side effect. Now sorts a copy: `[...props.teams].sort(...)`. *(`vue/no-mutating-props` + `vue/no-side-effects-in-computed-properties`)*
- **`SingleGameTypeEditor.vue`** — bound `v-model` directly to its `gameType` prop, and the parent passes the **store's original** object (not its edit clone). So typing mutated the store live and **Cancel could not revert**. Now edits a local copy and emits that on save/cancel. *(`vue/no-mutating-props`)*

## Reviewed but deliberately left
From the full report (272 problems, mostly noise): PrimeVue single-word component-name rules, accumulated `no-unused-vars`/`no-explicit-any`/non-null-assertion warnings, config-file `no-undef`, and 6 files ESLint's TS parser can't parse (they compile fine).
- `RegionList.vue` (missing-return) — **dead component, no users**; real fix is deletion, out of scope.
- `ExtraTimeOptionEditor.vue` (empty template root) — unfinished stub that renders nothing.
- `public_store.ts:128` `while(true)` — intentional poll loop with break + 3s timeout, not a bug.
- `SingleTournamentEditor.vue:69` prop writeback — intentional, only syncs the prop **after** a successful server save.
- `TeamList.vue:36` prop write — antipattern but functional; would need a parent-contract change.

## Verification
- `vue-tsc --noEmit` passes
- ESLint confirms all three targeted findings are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)